### PR TITLE
Added lcm_manual and gcd_manual

### DIFF
--- a/lib/utils/denominators.rb
+++ b/lib/utils/denominators.rb
@@ -1,0 +1,47 @@
+module Utils
+  def lcm_manual(num1, num2)
+    iterator = 2
+    loop do
+      break if (iterator % num1).zero? && (iterator % num2).zero?
+
+      iterator += 1
+    end
+    iterator
+  end
+
+  def gcd_manual(num1, num2)
+    save = Hash.new do |h, k|
+      h[k] = []
+    end
+
+    [num1, num2].each do |num|
+      start = 1
+      stop = num / 2 + 1
+
+      start.upto(stop) do |i|
+        save[num] << i if num % i == 0
+      end
+
+      save[num] << num
+    end
+
+    greatest = 1
+    save[num1].each do |n|
+      greatest = n if save[num2].include? n
+    end
+
+    greatest
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  include Utils
+
+  print 'GCD of 100, 150 : '
+  num = gcd_manual(100, 150)
+  puts num
+
+  print 'LCM of 100, 150: '
+  num = lcm_manual(100, 150)
+  puts num
+end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -15,3 +15,32 @@ RSpec.describe 'Utils#factorial_recursive' do
     expect(fact).to eq(120)
   end
 end
+
+RSpec.describe 'Utils#generate_array' do
+  it 'defaults to 10 elements' do
+    a = generate_array
+    expect(a.size).to eq(10)
+  end
+
+  it 'takes a parameter "elements"' do
+    a = generate_array(elements: 20)
+    expect(a.size).to eq(20)
+  end
+
+  it 'takes a parameter "max_element_size"' do
+    a = generate_array(max_element_size: 3)
+    expect(a.max).to eq(2)
+  end
+end
+
+RSpec.describe 'Utils#lcm_manual' do
+  it 'computes the least common multiple' do
+    lcm = lcm_manual(10, 7)
+    expect(lcm).to eq(10.lcm(7))
+  end
+
+  it 'computes the greatest common denominator' do
+    gcd = gcd_manual(100, 150)
+    expect(gcd).to eq(100.gcd(150))
+  end
+end


### PR DESCRIPTION
Methods for computing the least common multiple and greatest common
denominator between two numbers. Although ruby defines these methods on
the integer class, these were added just for the sake of writing the
algorithm.