### PR TITLE
Schwartzian Transform example

### DIFF
--- a/bin/schwartzian_transform.rb
+++ b/bin/schwartzian_transform.rb
@@ -1,0 +1,48 @@
+require 'rbconfig'
+require 'benchmark'
+
+path = File.join(RbConfig::CONFIG['prefix'].to_s, '**', '*')
+
+def files(path)
+  Dir.glob(path).select {|f| File.file? f}
+end
+
+schwartzian = Proc.new do
+  files(path).map {|f| [f, File.size(f)] }
+    .sort_by {|f| f[1]}
+    .map {|f| f[0]}
+end
+
+regular_sort = Proc.new do
+  files(path).sort {|a,b| File.size(a) <=> File.size(b)}
+end
+
+regular_sort_by = Proc.new do
+  files(path).sort_by {|a| File.size(a)}
+end
+
+Benchmark.bmbm do |x|
+  x.report('regular_sort') do
+    regular_sort.call
+  end
+
+  x.report('regular_sort_by') do
+    regular_sort_by.call
+  end
+
+  x.report('schwartzian') do
+    schwartzian.call
+  end
+end
+
+# Perform the two file checks (File.file? and File.size) in the same block
+# rather than chaining them when using the file method first.
+method1 = Proc.new do
+  files = Dir.glob(path).map do |f|
+    if File.file?(f)
+      [f, File.size(f)]
+    else
+      nil
+    end
+  end.compact.sort_by! {|a| a[1] }.map! {|f| f[0]}
+end


### PR DESCRIPTION
Benchmark three sorting methods that sort the files in Ruby's system
directory by size.

a) Plain block based sort using ruby's "sort { |a,b| ...}". For each
comparison, expensive system calls are made:
  File.size(a) <=> File.size(b)

b) Schwartzian sort exemplifies that calling the file size operation
once per file then saving the results in an array results in a much
faster sort.

c) Ruby's sort_by method uses the Schwartzian sort behind the scenes and
is just as performant.